### PR TITLE
INF-111 harden reusable frontend deploy and release workflows

### DIFF
--- a/.github/workflows/reusable-docker-deployment.yml
+++ b/.github/workflows/reusable-docker-deployment.yml
@@ -255,4 +255,3 @@ jobs:
 
       - name: Clean up Docker credentials
         run: rm -f /home/runner/.docker/config.json
-

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -230,8 +230,6 @@ jobs:
           tar -zcvf ./${{ inputs.repo-name }}.tar.gz -C dist .
           tar -zcvf ./${{ inputs.repo-name }}_nginx.tar.gz -C nginx .
 
-
-
       - name: "Configure SSH Key"
         if: ${{ !(inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet)) }}
         run: |

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -21,6 +21,10 @@ on:
         description: 'AWS region for S3 operations'
         required: true
         type: string
+      environment:
+        description: 'Explicit deployment environment: dev, testnet, or mainnet'
+        required: false
+        type: string
       isMainnet:
         description: 'Flag to indicate mainnet deployment'
         required: true
@@ -102,7 +106,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: "Configure AWS Credentials (Dev/Test)"
-        if: ${{ !inputs.isDapp && !inputs.isMainnet }}
+        if: ${{ !inputs.isDapp && !(inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet)) }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::381492270411:role/GitHubActionsOIDCRole
@@ -116,74 +120,96 @@ jobs:
           aws-region: ${{ inputs.s3-aws-region }}
 
       - name: "Configure AWS Credentials (Mainnet)"
-        if: ${{ inputs.isMainnet }}
+        if: ${{ inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet) }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: "Resolve Deployment Environment"
+        run: |
+          deploy_env="${{ inputs.environment }}"
+          if [ -z "${deploy_env}" ]; then
+            if [ "${{ inputs.isMainnet }}" = "true" ]; then
+              deploy_env="mainnet"
+            else
+              deploy_env="dev"
+            fi
+          fi
+
+          case "${deploy_env}" in
+            dev|testnet|mainnet)
+              ;;
+            *)
+              echo "Unsupported deployment environment: ${deploy_env}"
+              exit 1
+              ;;
+          esac
+
+          echo "DEPLOY_ENV=${deploy_env}" >> $GITHUB_ENV
+
       - name: "Fetch Nginx Certificates"
         run: |
-          # Determine secret prefix based on environment
-          if [ "${{ inputs.isMainnet }}" = "true" ]; then
-            prefix=${{ env.MAINNET_SECRET_PREFIX }}
-          elif [ -z "${{ secrets.EC2_HOST }}" ]; then
-            prefix=${{ env.DEV_SECRET_PREFIX }}
-          else
-            prefix=${{ env.TESTNET_SECRET_PREFIX }}
-          fi
+          secret_region="${{ inputs.s3-aws-region }}"
           if [ "${{ inputs.isDapp }}" = "true" ]; then
             prefix=${{ env.DAPP_SECRET_PREFIX }}
+          else
+            case "${DEPLOY_ENV}" in
+              mainnet)
+                prefix=${{ env.MAINNET_SECRET_PREFIX }}
+                secret_region="${{ env.AWS_REGION }}"
+                ;;
+              testnet)
+                prefix=${{ env.TESTNET_SECRET_PREFIX }}
+                ;;
+              *)
+                prefix=${{ env.DEV_SECRET_PREFIX }}
+                ;;
+            esac
           fi
+
           # Retrieve and decode
           secret=$(aws secretsmanager get-secret-value \
             --secret-id "${prefix}/nginx" \
-            --region ${{ inputs.s3-aws-region }} \
+            --region "${secret_region}" \
             --query SecretString --output text)
           echo "$secret" | jq -r .ssl_certificate > cloudflare.pem
           echo "$secret" | jq -r .ssl_key         > cloudflare.key
 
       - name: "Discover EC2 Instance"
         run: |
-          # Debug: print EC2_HOST as seen at the start (could be set via matrix/env)
-          echo "DEBUG: Before detection, EC2_HOST='${{ env.EC2_HOST }}'"
-
-          # Only query AWS if EC2_HOST is not already defined
-          if [ -z "${{ secrets.EC2_HOST }}" ]; then
-            echo "DEBUG: EC2_HOST is empty, querying AWS EC2..."
-
-            if [ "${{ inputs.isMainnet }}" = "true" ]; then
-              # Query mainnet EC2 by specific tag for its public DNS
+          if [ -n "${{ secrets.EC2_HOST }}" ]; then
+            echo "EC2_HOST=${{ secrets.EC2_HOST }}" >> $GITHUB_ENV
+          elif [ "${DEPLOY_ENV}" = "mainnet" ]; then
               public_dns=$(aws ec2 describe-instances \
                 --region ${{ env.AWS_REGION }} \
                 --filters "Name=tag:Name,Values=web-service-1-us-west-1" "Name=instance-state-name,Values=running" \
                 --query "Reservations[].Instances[].PublicDnsName" \
                 --output text)
 
-              echo "DEBUG: AWS returned PublicDnsName='${public_dns}'"
+              if [ -z "${public_dns}" ] || [ "${public_dns}" = "None" ]; then
+                echo "Unable to discover mainnet EC2 host automatically."
+                exit 1
+              fi
+
               echo "EC2_HOST=${public_dns}" >> $GITHUB_ENV
               echo "EC2_USER=ubuntu" >> $GITHUB_ENV
+          else
+            public_ip=$(aws ec2 describe-instances \
+              --region ${{ inputs.s3-aws-region }} \
+              --filters "Name=tag:Name,Values=${{ env.SERVICE_TAG }}" "Name=instance-state-name,Values=running" \
+              --query "Reservations[].Instances[].PublicIpAddress" \
+              --output text)
 
-            else
-              # Query dev/test EC2 by general tag for its public IP
-              public_ip=$(aws ec2 describe-instances \
-                --region ${{ inputs.s3-aws-region }} \
-                --filters "Name=tag:Name,Values=${{ env.SERVICE_TAG }}" "Name=instance-state-name,Values=running" \
-                --query "Reservations[].Instances[].PublicIpAddress" \
-                --output text)
-
-              echo "DEBUG: AWS returned PublicIpAddress='${public_ip}'"
-              echo "EC2_HOST=${public_ip}" >> $GITHUB_ENV
-              echo "EC2_USER=ubuntu" >> $GITHUB_ENV
-
+            if [ -z "${public_ip}" ] || [ "${public_ip}" = "None" ]; then
+              echo "Unable to discover ${DEPLOY_ENV} EC2 host automatically."
+              exit 1
             fi
 
-          else
-            echo "DEBUG: EC2_HOST already set to '${{ env.EC2_HOST }}', skipping AWS query"
+            echo "EC2_HOST=${public_ip}" >> $GITHUB_ENV
+            echo "EC2_USER=ubuntu" >> $GITHUB_ENV
           fi
-
-
-
 
       - name: "Install Dependencies and Build"
         run: |
@@ -209,7 +235,7 @@ jobs:
           # Choose bucket based on environment
           if [ "${{ inputs.isDapp }}" = "true" ]; then
             bucket=${{ env.DAPP_BUCKET_NAME }}
-          elif [ "${{ inputs.isMainnet }}" = "true" ]; then
+          elif [ "${DEPLOY_ENV}" = "mainnet" ]; then
             bucket=${{ env.MAINNET_BUCKET_NAME }}
           else
             bucket=${{ env.BUCKET_NAME }}
@@ -220,15 +246,8 @@ jobs:
           aws s3 cp ./${{ inputs.repo-name }}.tar.gz s3://$bucket/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_${{ env.TIME }}.tar.gz
           aws s3 cp ./${{ inputs.repo-name }}_nginx.tar.gz s3://$bucket/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_nginx_${{ env.TIME }}.tar.gz
           
-      - name: “Override EC2_HOST from Secret if present”
-        run: |
-          # If secrets.EC2_HOST is set, write it into GITHUB_ENV so later steps see it
-          if [ -n "${{ secrets.EC2_HOST }}" ]; then
-            echo "EC2_HOST=${{ secrets.EC2_HOST }}" >> $GITHUB_ENV
-          fi
-
       - name: "Deploy to Dev/Test EC2"
-        if: ${{ !inputs.isMainnet }}
+        if: ${{ !(inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet)) }}
         run: |
           # 1) Set local variables for path & bucket
           if [ "${{ inputs.isDapp }}" = "true" ]; then
@@ -256,9 +275,11 @@ jobs:
           EOF
 
       - name: "Configure SSH for Cloudflare Access"
-        if: ${{ inputs.isMainnet }}
+        if: ${{ inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet) }}
         run: |
           mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          chmod 600 ~/.ssh/tn-mainnet-gha
           cat >> ~/.ssh/config << 'EOF'
           Host us-west-1-jump-server.treasurenet.io
             ProxyCommand cloudflared access ssh --hostname %h
@@ -271,7 +292,7 @@ jobs:
           chmod 600 ~/.ssh/config
 
       - name: "Deploy to Mainnet EC2 via Bastion"
-        if: ${{ inputs.isMainnet }}
+        if: ${{ inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet) }}
         run: |
           # SSH into bastion, then into target host, and unpack
           ssh us-west-1-jump-server.treasurenet.io <<OUTER
@@ -294,7 +315,7 @@ jobs:
           OUTER
 
       - name: "Restart Nginx (Dev/Test)"
-        if: ${{ !inputs.isMainnet }}
+        if: ${{ !(inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet)) }}
         run: |
           ssh -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST <<EOF
           cd ${{ env.NGINX_PATH }}
@@ -306,7 +327,7 @@ jobs:
           EOF
 
       - name: "Restart Nginx (Mainnet)"
-        if: ${{ inputs.isMainnet }}
+        if: ${{ inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet) }}
         run: |
           # First hop: to Bastion
           ssh us-west-1-jump-server.treasurenet.io <<OUTER

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -37,11 +37,11 @@ on:
         description: 'Private SSH key to connect to EC2'
         required: true
       EC2_USER:
-        description: 'Username for SSH on EC2'
-        required: true
+        description: 'Username for SSH on EC2; optional when the workflow discovers the target automatically'
+        required: false
       EC2_HOST:
-        description: 'EC2 hostname or IP'
-        required: true
+        description: 'EC2 hostname or IP; optional when the workflow discovers the target automatically'
+        required: false
       CLOUDFLARE_API_TOKEN:
         description: 'Cloudflare API token for cache purge'
         required: true
@@ -224,7 +224,7 @@ jobs:
 
 
       - name: "Configure SSH Key"
-        if: ${{ !inputs.isMainnet }}
+        if: ${{ !(inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet)) }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -216,6 +216,12 @@ jobs:
       - name: "Install Dependencies and Build"
         run: |
           npm install --silent
+          npm run validate:local
+          test -f nginx/conf.d/airdrop-manager-dev.conf
+          test -f nginx/conf.d/airdrop-manager-testnet.conf
+          test -f nginx/conf.d/airdrop-manager-mainnet.conf
+          test -f nginx/conf.d/snippets/airdrop-manager-spa-common.conf
+          test -f nginx/conf.d/snippets/airdrop-manager-proxy-common.conf
           npm run ${{ inputs.build-command }} --silent
 
       - name: "Package Build Artifacts"

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -217,11 +217,12 @@ jobs:
         run: |
           npm install --silent
           npm run validate:local
-          test -f nginx/conf.d/airdrop-manager-dev.conf
-          test -f nginx/conf.d/airdrop-manager-testnet.conf
-          test -f nginx/conf.d/airdrop-manager-mainnet.conf
-          test -f nginx/conf.d/snippets/airdrop-manager-spa-common.conf
-          test -f nginx/conf.d/snippets/airdrop-manager-proxy-common.conf
+          test -d nginx
+          test -d nginx/conf.d
+          find nginx/conf.d -maxdepth 1 -type f -name '*.conf' | grep -q .
+          if [ -d nginx/conf.d/snippets ]; then
+            find nginx/conf.d/snippets -maxdepth 1 -type f -name '*.conf' | grep -q .
+          fi
           npm run ${{ inputs.build-command }} --silent
 
       - name: "Package Build Artifacts"

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -148,6 +148,8 @@ jobs:
           esac
 
           echo "DEPLOY_ENV=${deploy_env}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_PATH=${{ env.AWS_DEFAULT_DEPLOYMENT_PATH }}/${{ inputs.repo-name }}/${deploy_env}" >> $GITHUB_ENV
+          echo "MAINNET_DEPLOYMENT_PATH=${{ env.MAINNET_DEPLOYMENT_PATH }}/${{ inputs.repo-name }}/${deploy_env}" >> $GITHUB_ENV
 
       - name: "Fetch Nginx Certificates"
         run: |
@@ -263,9 +265,9 @@ jobs:
           aws s3 cp s3://$bucket/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.key /data/nginx/certs/cloudflare.key
 
           aws s3 cp s3://$bucket/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_${{ env.TIME }}.tar.gz /home/${{ env.EC2_USER }}/${{ inputs.repo-name }}.tar.gz
-           mkdir -p /data/treasurenet/${{ inputs.repo-name }}
-           rm -rf /data/treasurenet/${{ inputs.repo-name }}/*
-          tar -zxf /home/${{ env.EC2_USER }}/${{ inputs.repo-name }}.tar.gz -C /data/treasurenet/${{ inputs.repo-name }}
+          mkdir -p "${{ env.DEPLOYMENT_PATH }}"
+          rm -rf "${{ env.DEPLOYMENT_PATH }}"/*
+          tar -zxf /home/${{ env.EC2_USER }}/${{ inputs.repo-name }}.tar.gz -C "${{ env.DEPLOYMENT_PATH }}"
           rm -rf /home/${{ env.EC2_USER }}/${{ inputs.repo-name }}.tar.gz
 
           aws s3 cp s3://$bucket/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_nginx_${{ env.TIME }}.tar.gz /home/${{ env.EC2_USER }}/${{ inputs.repo-name }}_nginx.tar.gz
@@ -302,9 +304,9 @@ jobs:
           aws s3 cp s3://tn-mainnet-deployment-file-archive/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.key /home/ubuntu/nginx/certs/cloudflare.key
 
           aws s3 cp s3://tn-mainnet-deployment-file-archive/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_${{ env.TIME }}.tar.gz /home/ubuntu/${{ inputs.repo-name }}.tar.gz
-          mkdir -p /home/ubuntu/treasurenet/${{ inputs.repo-name }}
-           rm -rf /home/ubuntu/treasurenet/${{ inputs.repo-name }}/*
-          tar -zxf /home/ubuntu/${{ inputs.repo-name }}.tar.gz -C /home/ubuntu/treasurenet/${{ inputs.repo-name }}
+          mkdir -p "${{ env.MAINNET_DEPLOYMENT_PATH }}"
+          rm -rf "${{ env.MAINNET_DEPLOYMENT_PATH }}"/*
+          tar -zxf /home/ubuntu/${{ inputs.repo-name }}.tar.gz -C "${{ env.MAINNET_DEPLOYMENT_PATH }}"
           rm -rf /home/ubuntu/${{ inputs.repo-name }}.tar.gz
 
           aws s3 cp s3://tn-mainnet-deployment-file-archive/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_nginx_${{ env.TIME }}.tar.gz /home/ubuntu/${{ inputs.repo-name }}_nginx.tar.gz

--- a/.github/workflows/reusable-frontend-build-deployment.yml
+++ b/.github/workflows/reusable-frontend-build-deployment.yml
@@ -285,7 +285,12 @@ jobs:
         if: ${{ inputs.environment == 'mainnet' || (inputs.environment == '' && inputs.isMainnet) }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          if [ -n "${{ secrets.EC2_SSH_KEY }}" ]; then
+            echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          elif [ ! -s ~/.ssh/tn-mainnet-gha ]; then
+            echo "Mainnet SSH key is not available via secret or pre-provisioned runner file."
+            exit 1
+          fi
           chmod 600 ~/.ssh/tn-mainnet-gha
           cat >> ~/.ssh/config << 'EOF'
           Host us-west-1-jump-server.treasurenet.io

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Install dependencies and build
         run: |
           npm install --silent
+          npm run validate:local
+          test -f nginx/conf.d/airdrop-manager-dev.conf
+          test -f nginx/conf.d/airdrop-manager-testnet.conf
+          test -f nginx/conf.d/airdrop-manager-mainnet.conf
+          test -f nginx/conf.d/snippets/airdrop-manager-spa-common.conf
+          test -f nginx/conf.d/snippets/airdrop-manager-proxy-common.conf
           npm run ${{ inputs.build-command }} --silent
 
       - name: Prepare release artifacts

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -31,10 +31,6 @@ on:
         description: 'Workflow run id that produced the package artifact for mainnet deployment'
         required: false
         type: string
-      artifact-name:
-        description: 'Artifact name to package or deploy'
-        required: true
-        type: string
     secrets:
       EC2_SSH_KEY:
         description: 'Private SSH key to connect to EC2'
@@ -84,7 +80,7 @@ jobs:
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.repo-name }}-${{ inputs.environment }}-release
           path: release-artifacts
           if-no-files-found: error
 
@@ -133,7 +129,7 @@ jobs:
       - name: Download packaged artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.repo-name }}-${{ inputs.environment }}-release
           path: release-artifacts
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -1,0 +1,252 @@
+name: "Frontend Release"
+
+on:
+  workflow_call:
+    inputs:
+      repo-name:
+        description: 'Name of the repository/artifact'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version to use'
+        required: true
+        type: string
+      build-command:
+        description: 'npm build script to run'
+        required: true
+        type: string
+      s3-aws-region:
+        description: 'AWS region for S3 operations'
+        required: true
+        type: string
+      environment:
+        description: 'Release environment: testnet or mainnet'
+        required: true
+        type: string
+      release-action:
+        description: 'Release action: testnet-release, mainnet-package, or mainnet-deploy'
+        required: true
+        type: string
+      package-run-id:
+        description: 'Workflow run id that produced the package artifact for mainnet deployment'
+        required: false
+        type: string
+      artifact-name:
+        description: 'Artifact name to package or deploy'
+        required: true
+        type: string
+    secrets:
+      EC2_SSH_KEY:
+        description: 'Private SSH key to connect to EC2'
+        required: false
+      EC2_USER:
+        description: 'Username for SSH on EC2'
+        required: false
+      EC2_HOST:
+        description: 'EC2 hostname or IP'
+        required: false
+      CLOUDFLARE_API_TOKEN:
+        description: 'Cloudflare API token for cache purge'
+        required: true
+      CLOUDFLARE_ZONE_ID:
+        description: 'Cloudflare zone identifier'
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  package:
+    if: ${{ inputs.release-action != 'mainnet-deploy' }}
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies and build
+        run: |
+          npm install --silent
+          npm run ${{ inputs.build-command }} --silent
+
+      - name: Prepare release artifacts
+        run: |
+          mkdir -p release-artifacts
+          tar -zcvf release-artifacts/${{ inputs.repo-name }}.tar.gz -C dist .
+          tar -zcvf release-artifacts/${{ inputs.repo-name }}_nginx.tar.gz -C nginx .
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: release-artifacts
+          if-no-files-found: error
+
+  deploy-testnet:
+    if: ${{ inputs.release-action == 'testnet-release' }}
+    needs: [ package ]
+    uses: treasurenetprotocol/reusable-workflows/.github/workflows/reusable-frontend-build-deployment.yml@chore/inf-111-reusable-frontend-deploy-alignment
+    with:
+      repo-name: ${{ inputs.repo-name }}
+      node-version: ${{ inputs.node-version }}
+      build-command: ${{ inputs.build-command }}
+      s3-aws-region: ${{ inputs.s3-aws-region }}
+      environment: "testnet"
+      isMainnet: false
+    secrets:
+      EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+      EC2_USER: ${{ secrets.EC2_USER }}
+      EC2_HOST: ${{ secrets.EC2_HOST }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+  deploy-mainnet:
+    if: ${{ inputs.release-action == 'mainnet-deploy' }}
+    runs-on: self-hosted
+    env:
+      AWS_ROLE_ARN: "arn:aws:iam::471112752664:role/GitHubAction-AssumeRoleWithAction"
+      AWS_REGION: "us-west-1"
+      MAINNET_DEPLOYMENT_PATH: "/home/ubuntu/treasurenet"
+      MAINNET_BUCKET_NAME: "tn-mainnet-deployment-file-archive"
+      MAINNET_SECRET_PREFIX: "mainnet/services"
+      MAINNET_NGINX_PATH: "/home/ubuntu/nginx"
+    steps:
+      - name: Validate deploy inputs
+        run: |
+          if [ -z "${{ inputs.package-run-id }}" ]; then
+            echo "package-run-id is required for mainnet-deploy."
+            exit 1
+          fi
+
+      - name: Set release metadata
+        run: |
+          echo "DATE=$(date '+%Y%m%d')" >> $GITHUB_ENV
+          echo "TIME=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
+          echo "DEPLOYMENT_PATH=${{ env.MAINNET_DEPLOYMENT_PATH }}/${{ inputs.repo-name }}/mainnet" >> $GITHUB_ENV
+
+      - name: Download packaged artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: release-artifacts
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.package-run-id }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup cloudflared
+        run: |
+          sudo mkdir -p --mode=0755 /usr/share/keyrings
+          curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+          sudo apt-get update && sudo apt-get install cloudflared
+
+      - name: Fetch nginx certificates
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ env.MAINNET_SECRET_PREFIX }}/nginx" \
+            --region ${{ env.AWS_REGION }} \
+            --query SecretString --output text)
+          echo "$secret" | jq -r .ssl_certificate > cloudflare.pem
+          echo "$secret" | jq -r .ssl_key > cloudflare.key
+
+      - name: Discover mainnet EC2 host
+        run: |
+          if [ -n "${{ secrets.EC2_HOST }}" ]; then
+            echo "EC2_HOST=${{ secrets.EC2_HOST }}" >> $GITHUB_ENV
+          else
+            public_dns=$(aws ec2 describe-instances \
+              --region ${{ env.AWS_REGION }} \
+              --filters "Name=tag:Name,Values=web-service-1-us-west-1" "Name=instance-state-name,Values=running" \
+              --query "Reservations[].Instances[].PublicDnsName" \
+              --output text)
+
+            if [ -z "${public_dns}" ] || [ "${public_dns}" = "None" ]; then
+              echo "Unable to discover mainnet EC2 host automatically."
+              exit 1
+            fi
+
+            echo "EC2_HOST=${public_dns}" >> $GITHUB_ENV
+          fi
+
+      - name: Configure SSH for Cloudflare Access
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          chmod 600 ~/.ssh/tn-mainnet-gha
+          cat >> ~/.ssh/config << 'EOF'
+          Host us-west-1-jump-server.treasurenet.io
+            ProxyCommand cloudflared access ssh --hostname %h
+            User ec2-user
+            IdentityFile ~/.ssh/tn-mainnet-gha
+            StrictHostKeyChecking no
+            ServerAliveInterval 60
+            ServerAliveCountMax 3
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Upload packaged release to S3
+        run: |
+          aws s3 cp cloudflare.pem s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.pem
+          aws s3 cp cloudflare.key s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.key
+          aws s3 cp release-artifacts/${{ inputs.repo-name }}.tar.gz s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_${{ env.TIME }}.tar.gz
+          aws s3 cp release-artifacts/${{ inputs.repo-name }}_nginx.tar.gz s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_nginx_${{ env.TIME }}.tar.gz
+
+      - name: Deploy to mainnet EC2 via bastion
+        run: |
+          ssh us-west-1-jump-server.treasurenet.io <<OUTER
+          ssh -o StrictHostKeyChecking=no -i ~/mainnet-nodes-us-west-1.pem ubuntu@${EC2_HOST} <<INNER
+          mkdir -p /home/ubuntu/nginx/certs
+          aws s3 cp s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.pem /home/ubuntu/nginx/certs/cloudflare.pem
+          aws s3 cp s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/cloudflare.key /home/ubuntu/nginx/certs/cloudflare.key
+
+          aws s3 cp s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_${{ env.TIME }}.tar.gz /home/ubuntu/${{ inputs.repo-name }}.tar.gz
+          mkdir -p "${{ env.DEPLOYMENT_PATH }}"
+          rm -rf "${{ env.DEPLOYMENT_PATH }}"/*
+          tar -zxf /home/ubuntu/${{ inputs.repo-name }}.tar.gz -C "${{ env.DEPLOYMENT_PATH }}"
+          rm -rf /home/ubuntu/${{ inputs.repo-name }}.tar.gz
+
+          aws s3 cp s3://${{ env.MAINNET_BUCKET_NAME }}/${{ inputs.repo-name }}/${{ env.DATE }}/${{ inputs.repo-name }}_nginx_${{ env.TIME }}.tar.gz /home/ubuntu/${{ inputs.repo-name }}_nginx.tar.gz
+          tar -zxf /home/ubuntu/${{ inputs.repo-name }}_nginx.tar.gz --exclude='nginx.conf' -C /home/ubuntu/nginx/
+          rm -rf /home/ubuntu/${{ inputs.repo-name }}_nginx.tar.gz
+          INNER
+          OUTER
+
+      - name: Restart mainnet nginx
+        run: |
+          ssh us-west-1-jump-server.treasurenet.io <<OUTER
+          ssh -o StrictHostKeyChecking=no -i ~/mainnet-nodes-us-west-1.pem ubuntu@${EC2_HOST} <<INNER
+          cd ${{ env.MAINNET_NGINX_PATH }}
+          sed -i \
+            -e 's#/data/nginx#/home/ubuntu/nginx#g' \
+            -e 's#/data/treasurenet#/home/ubuntu/treasurenet#g' \
+            docker-compose.yaml
+          if docker compose ps | grep -q Up; then
+            docker compose restart
+          else
+            docker compose up -d
+          fi
+          INNER
+          OUTER
+
+      - name: Purge Cloudflare cache
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+          -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+          -H "Content-Type: application/json" \
+          --data '{"purge_everything":true}'

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -73,11 +73,12 @@ jobs:
         run: |
           npm install --silent
           npm run validate:local
-          test -f nginx/conf.d/airdrop-manager-dev.conf
-          test -f nginx/conf.d/airdrop-manager-testnet.conf
-          test -f nginx/conf.d/airdrop-manager-mainnet.conf
-          test -f nginx/conf.d/snippets/airdrop-manager-spa-common.conf
-          test -f nginx/conf.d/snippets/airdrop-manager-proxy-common.conf
+          test -d nginx
+          test -d nginx/conf.d
+          find nginx/conf.d -maxdepth 1 -type f -name '*.conf' | grep -q .
+          if [ -d nginx/conf.d/snippets ]; then
+            find nginx/conf.d/snippets -maxdepth 1 -type f -name '*.conf' | grep -q .
+          fi
           npm run ${{ inputs.build-command }} --silent
 
       - name: Prepare release artifacts

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -218,7 +218,12 @@ jobs:
       - name: Configure SSH for Cloudflare Access
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          if [ -n "${{ secrets.EC2_SSH_KEY }}" ]; then
+            echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/tn-mainnet-gha
+          elif [ ! -s ~/.ssh/tn-mainnet-gha ]; then
+            echo "Mainnet SSH key is not available via secret or pre-provisioned runner file."
+            exit 1
+          fi
           chmod 600 ~/.ssh/tn-mainnet-gha
           cat >> ~/.ssh/config << 'EOF'
           Host us-west-1-jump-server.treasurenet.io

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -125,7 +125,7 @@ jobs:
 
   deploy-testnet:
     if: ${{ inputs.release-action == 'testnet-release' }}
-    needs: [ package ]
+    needs: [package]
     uses: treasurenetprotocol/reusable-workflows/.github/workflows/reusable-frontend-build-deployment.yml@chore/inf-111-reusable-frontend-deploy-alignment
     with:
       repo-name: ${{ inputs.repo-name }}

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -90,15 +90,14 @@ jobs:
       - name: Compute release metadata
         id: release-metadata
         run: |
-          short_sha="${GITHUB_SHA::7}"
+          version="$(node -p "require('./package.json').version")"
           if [ "${{ inputs.release-action }}" = "testnet-release" ]; then
-            release_prefix="testnet-release"
+            release_tag="testnet-v${version}"
+            release_name="testnet v${version}"
           else
-            release_prefix="mainnet-package"
+            release_tag="v${version}"
+            release_name="mainnet v${version}"
           fi
-
-          release_tag="${release_prefix}-${GITHUB_RUN_NUMBER}-${short_sha}"
-          release_name="${release_prefix} ${GITHUB_RUN_NUMBER} (${short_sha})"
 
           echo "release-tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release-name=${release_name}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -50,13 +50,16 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   actions: read
 
 jobs:
   package:
     if: ${{ inputs.release-action != 'mainnet-deploy' }}
     runs-on: self-hosted
+    outputs:
+      release-tag: ${{ steps.release-metadata.outputs.release-tag }}
+      release-name: ${{ steps.release-metadata.outputs.release-name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,12 +80,41 @@ jobs:
           tar -zcvf release-artifacts/${{ inputs.repo-name }}.tar.gz -C dist .
           tar -zcvf release-artifacts/${{ inputs.repo-name }}_nginx.tar.gz -C nginx .
 
+      - name: Compute release metadata
+        id: release-metadata
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          if [ "${{ inputs.release-action }}" = "testnet-release" ]; then
+            release_prefix="testnet-release"
+          else
+            release_prefix="mainnet-package"
+          fi
+
+          release_tag="${release_prefix}-${GITHUB_RUN_NUMBER}-${short_sha}"
+          release_name="${release_prefix} ${GITHUB_RUN_NUMBER} (${short_sha})"
+
+          echo "release-tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "release-name=${release_name}" >> "$GITHUB_OUTPUT"
+
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.repo-name }}-${{ inputs.environment }}-release
           path: release-artifacts
           if-no-files-found: error
+
+      - name: Publish GitHub Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release-metadata.outputs.release-tag }}
+          name: ${{ steps.release-metadata.outputs.release-name }}
+          target_commitish: ${{ github.sha }}
+          draft: ${{ inputs.release-action == 'mainnet-package' }}
+          prerelease: ${{ inputs.release-action == 'testnet-release' }}
+          generate_release_notes: true
+          files: |
+            release-artifacts/${{ inputs.repo-name }}.tar.gz
+            release-artifacts/${{ inputs.repo-name }}_nginx.tar.gz
 
   deploy-testnet:
     if: ${{ inputs.release-action == 'testnet-release' }}

--- a/.github/workflows/reusable-frontend-release.yml
+++ b/.github/workflows/reusable-frontend-release.yml
@@ -92,11 +92,11 @@ jobs:
         run: |
           version="$(node -p "require('./package.json').version")"
           if [ "${{ inputs.release-action }}" = "testnet-release" ]; then
-            release_tag="testnet-v${version}"
-            release_name="testnet v${version}"
+            release_tag="testnet-v${version}-build.${GITHUB_RUN_NUMBER}"
+            release_name="testnet v${version} build ${GITHUB_RUN_NUMBER}"
           else
-            release_tag="v${version}"
-            release_name="mainnet v${version}"
+            release_tag="v${version}-build.${GITHUB_RUN_NUMBER}"
+            release_name="mainnet v${version} build ${GITHUB_RUN_NUMBER}"
           fi
 
           echo "release-tag=${release_tag}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Linked Ticket
- INF-111

## Scope
- add explicit environment-aware frontend deploy and release workflow contracts
- package both `dist` and `nginx`, deploy artifacts into environment-specific directories, and publish release assets for manual promotion flows
- generalize frontend validation so reusable workflows do not depend on repo-specific nginx filenames or config names

## Testing
- Not run yet
- PR opened before workflow validation by request

## Notes
- This PR targets `feat/add_job_deployment` because that branch already contains prerequisite deployment behavior that is not yet on `main`