### PR TITLE
INF-120: remove legacy contract state secret path

### DIFF
--- a/.github/workflows/reusable-docker-deployment.yml
+++ b/.github/workflows/reusable-docker-deployment.yml
@@ -103,6 +103,8 @@ jobs:
             export AWS_ACCESS_KEY_ID=${{env.AWS_ACCESS_KEY_ID}}
             export AWS_SECRET_ACCESS_KEY=${{env.AWS_SECRET_ACCESS_KEY}}
             export AWS_SESSION_TOKEN=${{env.AWS_SESSION_TOKEN}}
+            export AWS_REGION=${{ inputs.ecr-repo-aws-region }}
+            export AWS_DEFAULT_REGION=${{ inputs.ecr-repo-aws-region }}
             aws ecr get-login-password --region ${{ inputs.ecr-repo-aws-region }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
             docker-compose down
             docker-compose pull

--- a/.github/workflows/reuseable-contracts-deploy.yml
+++ b/.github/workflows/reuseable-contracts-deploy.yml
@@ -197,36 +197,6 @@ jobs:
             --content-type "application/json"
           echo "Uploaded ABI JSONs to $LATEST and $DATED"
 
-      - name: Update contract addresses in Secrets Manager
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_REGION }}
-          NETWORK: ${{ inputs.network }}
-          SECRET_ID: ${{ inputs.network }}/treasurenet-tnservices-dataprovider
-        run: |
-          set -euo pipefail
-          FILE="deployments/${NETWORK}.json"
-          OUT="/tmp/contract-addresses.json"
-          if [ ! -f "$FILE" ]; then
-            echo "Deployment file not found: $FILE" >&2
-            exit 1
-          fi
-          jq '(.entries | last) as $e | {
-                network: $e.network,
-                generatedAt: $e.generatedAt,
-                contracts: ($e.contracts | with_entries({key: .key, value: .value.address}))
-              }' "$FILE" > "$OUT"
-          if [ ! -s "$OUT" ]; then
-            echo "No data written to $OUT" >&2
-            exit 1
-          fi
-          aws secretsmanager put-secret-value \
-            --secret-id "$SECRET_ID" \
-            --secret-string file://"$OUT" \
-            --region "$AWS_DEFAULT_REGION"
-          echo "Updated secret $SECRET_ID with contract addresses from $FILE"
-
       - name: Upload deployments state to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}


### PR DESCRIPTION
## Summary
- stop writing contract deployment state into the dataprovider runtime secret path
- keep smart-contract deployment publishing limited to S3 deployment artifacts
- export AWS region variables into the remote docker compose shell so dataprovider can sync S3 artifacts at startup

## Validation
- workflow diff review only