### PR TITLE
INF-120: remove legacy contract state secret path

### DIFF
--- a/.github/workflows/reuseable-contracts-deploy.yml
+++ b/.github/workflows/reuseable-contracts-deploy.yml
@@ -198,39 +198,6 @@ jobs:
             --content-type "application/json"
           echo "Uploaded ABI JSONs to $LATEST and $DATED"
 
-      - name: Update contract deployment state in Secrets Manager
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_REGION }}
-          NETWORK: ${{ inputs.network }}
-          # Contract deployment state must not overwrite the dataprovider runtime
-          # secret. Dataprovider deployment expects a flat env-shaped payload,
-          # while this workflow writes structured deployment-state JSON.
-          SECRET_ID: ${{ inputs.network }}/${{ env.CONTRACT_STATE_SECRET_SUFFIX }}
-        run: |
-          set -euo pipefail
-          FILE="deployments/${NETWORK}.json"
-          OUT="/tmp/contract-deployment-state.json"
-          if [ ! -f "$FILE" ]; then
-            echo "Deployment file not found: $FILE" >&2
-            exit 1
-          fi
-          jq '(.entries | last) as $e | {
-                network: $e.network,
-                generatedAt: $e.generatedAt,
-                contracts: ($e.contracts | with_entries({key: .key, value: .value.address}))
-              }' "$FILE" > "$OUT"
-          if [ ! -s "$OUT" ]; then
-            echo "No data written to $OUT" >&2
-            exit 1
-          fi
-          aws secretsmanager put-secret-value \
-            --secret-id "$SECRET_ID" \
-            --secret-string file://"$OUT" \
-            --region "$AWS_DEFAULT_REGION"
-          echo "Updated secret $SECRET_ID with contract addresses from $FILE"
-
       - name: Upload deployments state to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}


### PR DESCRIPTION
## Summary
- Stop writing contract deployment state into the dataprovider runtime secret path
- Keep smart-contract deployment publishing limited to S3 deployment artifacts

## Validation
- workflow diff review only