### PR TITLE
docs: Create TN secret taxonomy and blocking rules INF-161

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.codex/plans/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 | Reusable Workflow | Description | Usage |
 | --------------- | --------------- | --------------- |
 | `reusable-timestamp.yml` | print out workflow start time | [README](docs/utility/readme-reusable-lint-go-workflow.md) |
+
+## Security Baselines
+| Asset | Description | Usage |
+| --------------- | --------------- | --------------- |
+| `docs/security/secret-taxonomy.md` | TN-wide secret taxonomy, severity model, and remediation rules | Read before tuning secret-scanning workflows |
+| `security/gitleaks/tn-gitleaks.toml` | Shared Gitleaks rules for TN-specific and general software-engineering secrets | Use from reusable secret-scanning workflows |

--- a/docs/security/secret-taxonomy.md
+++ b/docs/security/secret-taxonomy.md
@@ -1,0 +1,252 @@
+# TreasureNet Secret Taxonomy And Remediation Rules
+
+## Purpose
+
+This document defines the shared TreasureNet baseline for source-code secret detection. It is intended for GitHub Actions scanning, code review, incident triage, and repository cleanup work across TN repositories.
+
+## Non-Negotiable Remediation Principle
+
+Any private key, mnemonic, deployer credential, cloud credential, or production token committed to GitHub history must be treated as compromised.
+
+Deleting the file, reverting the commit, force-pushing, or rewriting Git history may reduce casual exposure, but it is not sufficient remediation. A real secret finding can only be closed after one of these outcomes is documented:
+
+- `rotated/revoked`
+- `abandoned`
+- `migrated`
+- `false positive`
+- `accepted residual exposure`
+
+`removed from repo` is not a valid final status for a real secret.
+
+## Severity Model
+
+| Severity | Meaning | Default CI Behavior |
+| --- | --- | --- |
+| Critical | Direct signing keys, mnemonics, private keys, production deployer credentials, production cloud credentials, or credentials that can control funds, infrastructure, releases, or production data. | Block PR/push immediately. |
+| High | Service tokens, database URLs with credentials, CI/CD tokens, package registry tokens, OAuth client secrets, webhook secrets, or credentials that can access non-public systems. | Block PR/push once the rule is stable. |
+| Medium | Suspicious high-entropy strings, non-production credentials, internal shared secrets, or context-dependent tokens requiring owner review. | Warn or block after tuning. |
+| Low | Weak signals, examples, fake fixtures, public identifiers, or values that require additional context. | Do not block by default. |
+
+## Secret Categories
+
+### Blockchain And Wallet Secrets
+
+Default severity: Critical.
+
+- EVM private keys, including `0x` and non-`0x` 32-byte hex keys.
+- Cosmos/TN private keys.
+- BIP39 mnemonic phrases.
+- Wallet keystore JSON containing encrypted private key material.
+- Hardhat, Foundry, Truffle, ethers.js, web3.js, or deployment script private keys.
+- Deployer, signer, oracle, bridge, feeder, relayer, faucet, treasury, or admin keys.
+- Any key able to move funds, deploy contracts, upgrade contracts, sign oracle data, mint, burn, bridge, or administer protocol contracts.
+
+Required remediation:
+
+- Abandon or rotate the key.
+- Move funds, ownership, roles, and signer permissions away from the exposed key.
+- Document residual on-chain authority if any cannot be moved.
+
+### Cloud And Infrastructure Secrets
+
+Default severity: Critical for production or privileged credentials; High otherwise.
+
+- AWS access keys and secret keys.
+- AWS session tokens.
+- GCP service account JSON and private keys.
+- Azure client secrets, tenant credentials, and publish profiles.
+- Terraform Cloud tokens and backend credentials.
+- Kubernetes kubeconfig files and service-account tokens.
+- Docker, ECR, GHCR, GCR, ACR, and other registry credentials.
+- Cloudflare, DNS provider, CDN, load-balancer, and certificate automation tokens.
+- VPN, bastion, SSH jump host, WireGuard, OpenVPN, or Tailscale credentials.
+
+Required remediation:
+
+- Revoke or rotate the credential at the provider.
+- Review audit logs for usage after exposure.
+- Replace affected CI/CD or runtime secret references.
+
+### GitHub, CI/CD, And Release Credentials
+
+Default severity: Critical or High.
+
+- GitHub personal access tokens.
+- GitHub App private keys.
+- GitHub Actions, CircleCI, GitLab, Jenkins, Buildkite, Drone, or ArgoCD tokens.
+- Deployment tokens, environment promotion credentials, release signing keys, and artifact publishing keys.
+- npm, Yarn, pnpm, PyPI, Maven, Gradle, RubyGems, NuGet, Go proxy, Cargo, Docker registry, and package publishing tokens.
+- SSH deploy keys and machine-user private keys.
+
+Required remediation:
+
+- Revoke or rotate the token/key.
+- Review repository, package, and release audit logs.
+- Check whether malicious packages, releases, workflows, or tags were created.
+
+### SaaS, Monitoring, And Communication Tokens
+
+Default severity: High.
+
+- Slack bot tokens, app tokens, webhook URLs, and signing secrets.
+- Discord, Telegram, DingTalk, Feishu/Lark, Teams, and webhook tokens.
+- SendGrid, Mailgun, SES SMTP, Postmark, Twilio, and SMS/email provider secrets.
+- Sentry auth tokens, Datadog, Grafana, Prometheus remote-write, New Relic, PagerDuty, Opsgenie, Honeycomb, Logtail, Loki, and observability API keys.
+- Notion, Linear, Jira, Confluence, Google Workspace, Google Drive, and document automation tokens.
+- Stripe, Plaid, Coinbase, Alchemy, Infura, QuickNode, WalletConnect, Moralis, The Graph, Etherscan, and blockchain infrastructure provider keys.
+
+Required remediation:
+
+- Rotate the token in the SaaS provider.
+- Review audit logs and webhook delivery history when available.
+- Remove the value from source and move it into the approved secret manager.
+
+### Database, Cache, Messaging, And Search Credentials
+
+Default severity: High.
+
+- PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Memcached, ClickHouse, Snowflake, BigQuery, DynamoDB, Elasticsearch, OpenSearch, Solr, Cassandra, and Neo4j credentials.
+- RabbitMQ, Kafka, NATS, MQTT, SQS, SNS, and queue/broker credentials.
+- DSNs or URLs containing usernames and passwords.
+- Root/admin database credentials in any format.
+
+Required remediation:
+
+- Rotate the password or credential.
+- Review database access logs where available.
+- Confirm application/runtime configuration has moved to secret-managed values.
+
+### Web, Authentication, And Application Secrets
+
+Default severity: High.
+
+- JWT signing secrets and private signing keys.
+- Session, cookie, CSRF, password-reset, invite, API signing, HMAC, encryption, and webhook verification secrets.
+- OAuth/OIDC/SAML client secrets.
+- Basic-auth URLs containing credentials.
+- Admin bootstrap passwords.
+- Encryption keys for application data, backups, cookies, and local storage.
+- CAPTCHA, Turnstile, reCAPTCHA, and anti-abuse secret keys.
+
+Required remediation:
+
+- Rotate signing/encryption material when feasible.
+- Invalidate affected sessions or tokens when the secret can sign or decrypt them.
+- Update all dependent services and clients.
+
+### Cryptographic Private Material
+
+Default severity: Critical.
+
+- SSH private keys.
+- TLS private keys.
+- PGP/GPG private keys.
+- PEM, PKCS#1, PKCS#8, OpenSSH, and PuTTY private key blocks.
+- Code-signing, mobile signing, notarization, and certificate authority keys.
+- Java keystore, Android keystore, iOS provisioning, App Store Connect, and Google Play signing secrets.
+
+Required remediation:
+
+- Revoke, rotate, or replace the key/certificate.
+- Reissue certificates and update trust chains where needed.
+- Review signing history and release artifacts.
+
+### Mobile And Client Distribution Secrets
+
+Default severity: High or Critical depending on capability.
+
+- Android keystores and keystore passwords.
+- iOS certificates, provisioning profiles, App Store Connect API keys, and fastlane match credentials.
+- Firebase service account keys and privileged server keys.
+- Push notification keys such as APNs auth keys and FCM server keys.
+- Mobile analytics or attribution admin tokens.
+
+Required remediation:
+
+- Rotate or revoke through the platform owner.
+- Confirm release pipelines and store credentials are updated.
+
+### Machine Learning, Data, And Third-Party Provider Keys
+
+Default severity: High.
+
+- OpenAI, Anthropic, Gemini, Cohere, Hugging Face, Replicate, Pinecone, Weaviate, Qdrant, vector database, and model provider keys.
+- Data warehouse, ETL, analytics, and BI provider tokens.
+- Internal vendor API keys with non-public data access.
+
+Required remediation:
+
+- Rotate the key.
+- Review usage and billing spikes.
+- Add rate limits or provider-side restrictions where available.
+
+### Generic High-Entropy Strings
+
+Default severity: Medium.
+
+High entropy alone is not enough to classify a finding as a real secret. It should be combined with path, variable name, assignment context, or provider pattern. Generic entropy rules must avoid blocking:
+
+- Hashes.
+- Checksums.
+- Transaction hashes.
+- Block hashes.
+- Public addresses.
+- Public keys.
+- Lockfiles.
+- Minified assets.
+- Test snapshots.
+
+## Values That Are Not Secrets By Default
+
+- Public blockchain addresses.
+- Transaction hashes.
+- Block hashes.
+- Public keys.
+- Public certificates without private key blocks.
+- `.env.example` placeholders.
+- Fake credentials in explicitly marked fixtures.
+- Non-sensitive DSNs that vendors intentionally expose publicly, unless paired with an auth token.
+
+## Allowlist Rules
+
+Allowlist entries must be narrow and justified. Prefer path-scoped or test-fixture-scoped allowlists over value-wide allowlists.
+
+Allowed examples:
+
+- `docs/example/**`
+- `**/.env.example`
+- `security/gitleaks/fixtures/**`
+- Clearly fake values containing `fake`, `dummy`, `example`, `placeholder`, or `not-a-real-secret`
+
+Disallowed examples:
+
+- Allowlisting all private-key-looking values.
+- Allowlisting production config paths.
+- Closing a finding because the secret was deleted from the latest branch.
+
+## Required Triage Fields
+
+Every real secret finding should record:
+
+- Repository.
+- File path.
+- Commit or PR.
+- Secret category.
+- Severity.
+- Scanner source.
+- Whether the secret is verified.
+- Suspected owner.
+- Runtime or environment impact.
+- Remediation status.
+- Remediation evidence.
+- Residual exposure decision, if any.
+
+## CI Blocking Policy
+
+PR and protected-branch scans should block:
+
+- Critical findings.
+- High findings from provider-specific rules.
+- Any verified TruffleHog credential.
+
+Initial rollout may warn on medium generic entropy findings until false positives are tuned.

--- a/security/gitleaks/README.md
+++ b/security/gitleaks/README.md
@@ -1,0 +1,27 @@
+# TN Gitleaks Configuration
+
+This directory contains TreasureNet's shared Gitleaks baseline.
+
+- `tn-gitleaks.toml`: shared rules and allowlists.
+- `fixtures/negative.txt`: fake public identifiers and placeholders that should not block.
+- `test-fixtures/generate-positive-fixture.sh`: creates a temporary fake-only positive fixture outside the committed source tree.
+
+The fixture files intentionally contain fake values only. Do not add real credentials to this repository for testing.
+
+## Validation
+
+If `gitleaks` is installed locally:
+
+```bash
+tmpdir="$(mktemp -d)"
+security/gitleaks/test-fixtures/generate-positive-fixture.sh "$tmpdir/positive.txt"
+gitleaks detect --no-git --source "$tmpdir" --config security/gitleaks/tn-gitleaks.toml --verbose
+gitleaks detect --no-git --source security/gitleaks/fixtures --config security/gitleaks/tn-gitleaks.toml --verbose
+```
+
+Expected behavior:
+
+- The generated temporary positive fixture should produce findings.
+- `fixtures/negative.txt` should not produce blocking findings.
+
+If `gitleaks` is not installed, validate TOML syntax and run lightweight regex checks against a generated positive fixture and the committed negative fixture.

--- a/security/gitleaks/fixtures/negative.txt
+++ b/security/gitleaks/fixtures/negative.txt
@@ -1,0 +1,10 @@
+# Fake-only negative examples for values that should not block by default.
+
+PUBLIC_EVM_ADDRESS=0x1111111111111111111111111111111111111111
+PUBLIC_TX_HASH=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+PUBLIC_BLOCK_HASH=0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+PUBLIC_KEY=03aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+SENTRY_DSN=https://public@example.ingest.sentry.io/123456
+ENV_EXAMPLE_VALUE=placeholder
+API_KEY=not-a-real-secret
+PASSWORD=changeme

--- a/security/gitleaks/test-fixtures/generate-positive-fixture.sh
+++ b/security/gitleaks/test-fixtures/generate-positive-fixture.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <output-file>" >&2
+  exit 64
+fi
+
+repeat_char() {
+  local char="$1"
+  local count="$2"
+  local value=""
+  local i
+  for ((i = 0; i < count; i += 1)); do
+    value="${value}${char}"
+  done
+  printf '%s' "$value"
+}
+
+output_file="$1"
+mkdir -p "$(dirname "$output_file")"
+hex_a_64="$(repeat_char a 64)"
+hex_b_64="$(repeat_char b 64)"
+alpha_a_24="$(repeat_char a 24)"
+alpha_a_32="$(repeat_char a 32)"
+alpha_a_35="$(repeat_char A 35)"
+alpha_a_36="$(repeat_char a 36)"
+alpha_a_40="$(repeat_char a 40)"
+alpha_a_60="$(repeat_char a 60)"
+alpha_b_36="$(repeat_char b 36)"
+alpha_c_36="$(repeat_char c 36)"
+mnemonic="$(printf 'abandon %.0s' {1..11})about"
+aws_id="AKIAIOSF""ODNN7EXAMPLE"
+aws_secret="wJalrXUtnFEMI/K7MD""ENG/bPxRfiCYEXAMPLEKEY"
+slack_prefix="xox""b-"
+pem_begin="-----BEGIN ""PRIVATE KEY""-----"
+pem_end="-----END ""PRIVATE KEY""-----"
+pg_url="postgres""://admin:super-secret-password@example.internal:5432/app"
+redis_url="redis""://default:super-secret-password@example.internal:6379/0"
+
+{
+  printf '%s\n' '# Fake-only positive examples for TN secret scanning rules.'
+  printf '%s\n' '# These values are intentionally non-production and must never be reused.'
+  printf '\n'
+  printf 'PRIVATE_KEY=0x%s\n' "$hex_a_64"
+  printf 'DEPLOYER_KEY=%s\n' "$hex_b_64"
+  printf 'MNEMONIC="%s"\n' "$mnemonic"
+  printf 'AWS_ACCESS_KEY_ID=%s\n' "$aws_id"
+  printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$aws_secret"
+  printf 'GITHUB_TOKEN=ghp_%s\n' "$alpha_a_36"
+  printf 'npm_token=npm_%s\n' "$alpha_a_36"
+  printf 'SLACK_BOT_TOKEN=%s111111111111-222222222222-%s\n' "$slack_prefix" "$alpha_a_24"
+  printf 'SLACK_WEBHOOK=https://hooks.slack.com/services/T00000000/B00000000/%s\n' "$alpha_a_24"
+  printf 'DISCORD_WEBHOOK=https://discord.com/api/webhooks/111111111111111111/%s\n' "$alpha_a_60"
+  printf 'TELEGRAM_BOT_TOKEN=123456789:%s\n' "$alpha_a_35"
+  printf 'SENDGRID_API_KEY=SG.%s.%s\n' "$alpha_a_24" "$alpha_a_32"
+  printf 'DATABASE_URL=%s\n' "$pg_url"
+  printf 'REDIS_URL=%s\n' "$redis_url"
+  printf 'JWT_SECRET="%s"\n' "$alpha_a_40"
+  printf 'SESSION_SECRET="%s"\n' "$alpha_b_36"
+  printf 'OAUTH_CLIENT_SECRET="%s"\n' "$alpha_c_36"
+  printf 'SENTRY_AUTH_TOKEN="sentry_auth_token_%s"\n' "$alpha_a_24"
+  printf 'GRAFANA_API_KEY="grafana_token_%s"\n' "$alpha_a_24"
+  printf 'OPENAI_API_KEY="openai_api_key_%s"\n' "$alpha_a_24"
+  printf 'FIREBASE_SERVER_KEY="firebase_server_key_%s"\n' "$alpha_a_24"
+  printf 'ANDROID_KEYSTORE_PASSWORD="android_keystore_password_%s"\n' "$alpha_a_24"
+  printf '%s\n' "$pem_begin"
+  printf '%s\n' 'placeholder-material-generated-for-test-only'
+  printf '%s\n' "$pem_end"
+} > "$output_file"

--- a/security/gitleaks/tn-gitleaks.toml
+++ b/security/gitleaks/tn-gitleaks.toml
@@ -1,0 +1,417 @@
+title = "TreasureNet shared secret scanning rules"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global TN allowlist for examples, generated files, and public identifiers"
+paths = [
+  '''(^|/)security/gitleaks/tn-gitleaks\.toml$''',
+  '''(^|/)security/gitleaks/test-fixtures/generate-positive-fixture\.sh$''',
+  '''(^|/)docs/example/''',
+  '''(^|/)\.env\.example$''',
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)pnpm-lock\.yaml$''',
+  '''(^|/)yarn\.lock$''',
+  '''(^|/)go\.sum$''',
+  '''(^|/)Cargo\.lock$'''
+]
+regexes = [
+  '''(?i)(fake|dummy|example|placeholder|not-a-real-secret|changeme|test-only)''',
+  '''0x[a-fA-F0-9]{40}'''
+]
+
+[[rules]]
+id = "tn-evm-private-key"
+description = "EVM-style 32-byte private key assigned to a sensitive variable"
+severity = "critical"
+regex = '''(?i)(private[_-]?key|deployer[_-]?key|signer[_-]?key|wallet[_-]?key|owner[_-]?key|operator[_-]?key|relayer[_-]?key|oracle[_-]?key|faucet[_-]?key|treasury[_-]?key|admin[_-]?key)\s*[:=]\s*['"]?(0x)?[a-f0-9]{64}['"]?'''
+keywords = [
+  "privatekey",
+  "private_key",
+  "deployer",
+  "signer",
+  "relayer",
+  "oracle",
+  "faucet",
+  "treasury"
+]
+
+[[rules]]
+id = "tn-bip39-mnemonic-assignment"
+description = "BIP39 mnemonic assigned to a seed or wallet variable"
+severity = "critical"
+regex = '''(?i)(mnemonic|seed[_-]?phrase|recovery[_-]?phrase)\s*[:=]\s*['"]?([a-z]{3,12}\s+){11,23}[a-z]{3,12}['"]?'''
+keywords = [
+  "mnemonic",
+  "seed phrase",
+  "recovery phrase"
+]
+
+[[rules]]
+id = "tn-wallet-keystore-json"
+description = "Wallet keystore JSON containing encrypted private key material"
+severity = "critical"
+regex = '''(?i)"crypto"\s*:\s*\{[\s\S]{0,1200}"ciphertext"\s*:\s*"[a-f0-9]{64,}"'''
+keywords = [
+  "ciphertext",
+  "crypto",
+  "keystore"
+]
+
+[[rules]]
+id = "tn-pem-private-key"
+description = "PEM or OpenSSH private key block"
+severity = "critical"
+regex = '''-----BEGIN (RSA |DSA |EC |OPENSSH |PGP |ENCRYPTED |)?PRIVATE KEY-----'''
+keywords = [
+  "PRIVATE KEY"
+]
+
+[[rules]]
+id = "tn-aws-access-key-id"
+description = "AWS access key ID"
+severity = "high"
+regex = '''\b(A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}\b'''
+keywords = [
+  "AKIA",
+  "ASIA"
+]
+
+[[rules]]
+id = "tn-aws-secret-access-key"
+description = "AWS secret access key assigned to a sensitive variable"
+severity = "critical"
+regex = '''(?i)(aws_)?secret(_access)?_key\s*[:=]\s*['"]?[A-Za-z0-9/+=]{40}['"]?'''
+keywords = [
+  "secret_access_key",
+  "aws_secret"
+]
+
+[[rules]]
+id = "tn-gcp-service-account-private-key"
+description = "GCP service account private key JSON"
+severity = "critical"
+regex = '''(?s)"type"\s*:\s*"service_account".{0,2000}"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----'''
+keywords = [
+  "service_account",
+  "private_key"
+]
+
+[[rules]]
+id = "tn-azure-client-secret"
+description = "Azure client secret assigned to a sensitive variable"
+severity = "high"
+regex = '''(?i)(azure|aad|tenant).{0,40}(client[_-]?secret|app[_-]?secret|password)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "azure",
+  "client_secret"
+]
+
+[[rules]]
+id = "tn-github-token"
+description = "GitHub personal, fine-grained, app, or refresh token"
+severity = "high"
+regex = '''\b(ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{30,255}\b'''
+keywords = [
+  "ghp_",
+  "github_pat"
+]
+
+[[rules]]
+id = "tn-github-app-private-key"
+description = "GitHub App private key"
+severity = "critical"
+regex = '''(?s)-----BEGIN RSA PRIVATE KEY-----.{0,2000}github.{0,2000}app'''
+keywords = [
+  "github",
+  "PRIVATE KEY"
+]
+
+[[rules]]
+id = "tn-npm-token"
+description = "npm package publishing token"
+severity = "high"
+regex = '''\bnpm_[A-Za-z0-9]{36}\b'''
+keywords = [
+  "npm_"
+]
+
+[[rules]]
+id = "tn-package-registry-token-assignment"
+description = "Package registry token assignment"
+severity = "high"
+regex = '''(?i)(npm|yarn|pnpm|pypi|twine|maven|gradle|rubygems|nuget|cargo|registry).{0,30}(token|password|secret|key)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "registry",
+  "token",
+  "npm",
+  "pypi"
+]
+
+[[rules]]
+id = "tn-docker-registry-auth"
+description = "Docker or container registry credential"
+severity = "high"
+regex = '''(?i)(docker|ecr|ghcr|gcr|acr|registry).{0,40}(password|token|auth)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "docker",
+  "registry",
+  "ghcr",
+  "ecr"
+]
+
+[[rules]]
+id = "tn-kubernetes-token-or-kubeconfig"
+description = "Kubernetes kubeconfig token or client credential"
+severity = "critical"
+regex = '''(?i)(client-key-data|token)\s*:\s*[A-Za-z0-9._~+/=-]{40,}'''
+keywords = [
+  "client-key-data",
+  "kubeconfig"
+]
+
+[[rules]]
+id = "tn-terraform-cloud-token"
+description = "Terraform Cloud or IaC token"
+severity = "high"
+regex = '''(?i)(terraform|tf_cloud|tfc).{0,40}(token|api[_-]?key)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "terraform",
+  "tfc",
+  "token"
+]
+
+[[rules]]
+id = "tn-cloudflare-token"
+description = "Cloudflare API token"
+severity = "high"
+regex = '''(?i)(cloudflare|cf).{0,40}(api[_-]?token|global[_-]?key|account[_-]?token)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "cloudflare",
+  "api_token"
+]
+
+[[rules]]
+id = "tn-slack-token"
+description = "Slack bot, app, user, or webhook token"
+severity = "high"
+regex = '''\bxox[baprs]-[A-Za-z0-9-]{20,}\b'''
+keywords = [
+  "xoxb-",
+  "xoxa-",
+  "xoxp-"
+]
+
+[[rules]]
+id = "tn-slack-webhook"
+description = "Slack webhook URL"
+severity = "high"
+regex = '''https://hooks\.slack\.com/services/T[A-Z0-9]{8,}/B[A-Z0-9]{8,}/[A-Za-z0-9]{20,}'''
+keywords = [
+  "hooks.slack.com"
+]
+
+[[rules]]
+id = "tn-discord-webhook"
+description = "Discord webhook URL"
+severity = "high"
+regex = '''https://discord(?:app)?\.com/api/webhooks/[0-9]{17,20}/[A-Za-z0-9._-]{50,}'''
+keywords = [
+  "discord.com/api/webhooks",
+  "discordapp.com/api/webhooks"
+]
+
+[[rules]]
+id = "tn-telegram-bot-token"
+description = "Telegram bot token"
+severity = "high"
+regex = '''\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b'''
+keywords = [
+  "telegram",
+  "bot"
+]
+
+[[rules]]
+id = "tn-sendgrid-token"
+description = "SendGrid API token"
+severity = "high"
+regex = '''\bSG\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b'''
+keywords = [
+  "SG."
+]
+
+[[rules]]
+id = "tn-mailgun-token"
+description = "Mailgun API key"
+severity = "high"
+regex = '''\bkey-[A-Za-z0-9]{32}\b'''
+keywords = [
+  "mailgun",
+  "key-"
+]
+
+[[rules]]
+id = "tn-sentry-auth-token"
+description = "Sentry auth token assignment"
+severity = "high"
+regex = '''(?i)(sentry).{0,40}(auth[_-]?token|api[_-]?token)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "sentry",
+  "auth_token"
+]
+
+[[rules]]
+id = "tn-observability-token"
+description = "Observability provider token assignment"
+severity = "high"
+regex = '''(?i)(grafana|datadog|newrelic|honeycomb|pagerduty|opsgenie|logtail|loki|prometheus).{0,40}(token|api[_-]?key|password|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "grafana",
+  "datadog",
+  "newrelic",
+  "api_key"
+]
+
+[[rules]]
+id = "tn-notion-linear-token"
+description = "Notion or Linear token assignment"
+severity = "high"
+regex = '''(?i)(notion|linear).{0,40}(token|api[_-]?key|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "notion",
+  "linear",
+  "api_key"
+]
+
+[[rules]]
+id = "tn-database-url-with-password"
+description = "Database or cache URL containing credentials"
+severity = "high"
+regex = '''(?i)\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss|amqp|amqps|kafka|elasticsearch|opensearch|clickhouse)://[^/\s:@]+:[^@\s]+@[^/\s]+'''
+keywords = [
+  "postgres://",
+  "postgresql://",
+  "mysql://",
+  "mongodb://",
+  "redis://",
+  "amqp://"
+]
+
+[[rules]]
+id = "tn-jwt-secret-assignment"
+description = "JWT signing secret assignment"
+severity = "high"
+regex = '''(?i)(jwt|token).{0,30}(secret|signing[_-]?key|private[_-]?key)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "jwt",
+  "signing",
+  "secret"
+]
+
+[[rules]]
+id = "tn-session-cookie-secret"
+description = "Session, cookie, CSRF, or HMAC secret assignment"
+severity = "high"
+regex = '''(?i)(session|cookie|csrf|hmac|webhook|encryption|encrypt|decrypt).{0,40}(secret|key|salt|password)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "session",
+  "cookie",
+  "csrf",
+  "hmac",
+  "secret"
+]
+
+[[rules]]
+id = "tn-oauth-client-secret"
+description = "OAuth/OIDC/SAML client secret assignment"
+severity = "high"
+regex = '''(?i)(oauth|oidc|saml|client).{0,40}(client[_-]?secret|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "client_secret",
+  "oauth",
+  "oidc"
+]
+
+[[rules]]
+id = "tn-basic-auth-url"
+description = "HTTP URL containing basic-auth credentials"
+severity = "high"
+regex = '''https?://[^/\s:@]+:[^@\s]+@[^/\s]+'''
+keywords = [
+  "http://",
+  "https://"
+]
+
+[[rules]]
+id = "tn-stripe-secret-key"
+description = "Stripe secret or restricted API key"
+severity = "high"
+regex = '''\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{20,}\b'''
+keywords = [
+  "sk_live_",
+  "rk_live_",
+  "sk_test_"
+]
+
+[[rules]]
+id = "tn-blockchain-provider-key"
+description = "Blockchain infrastructure provider API key assignment"
+severity = "high"
+regex = '''(?i)(alchemy|infura|quicknode|moralis|walletconnect|etherscan|polygonscan|arbiscan|basescan|thegraph|graph).{0,40}(api[_-]?key|token|secret|project[_-]?id)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "alchemy",
+  "infura",
+  "quicknode",
+  "etherscan",
+  "walletconnect"
+]
+
+[[rules]]
+id = "tn-ai-provider-key"
+description = "AI, vector database, or model provider API key assignment"
+severity = "high"
+regex = '''(?i)(openai|anthropic|gemini|cohere|huggingface|replicate|pinecone|weaviate|qdrant).{0,40}(api[_-]?key|token|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "openai",
+  "anthropic",
+  "pinecone",
+  "api_key"
+]
+
+[[rules]]
+id = "tn-firebase-or-push-secret"
+description = "Firebase, APNs, or push notification private/server key"
+severity = "high"
+regex = '''(?i)(firebase|fcm|apns|push).{0,40}(server[_-]?key|private[_-]?key|auth[_-]?key|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{20,}['"]'''
+keywords = [
+  "firebase",
+  "fcm",
+  "apns"
+]
+
+[[rules]]
+id = "tn-mobile-signing-secret"
+description = "Mobile signing, keystore, provisioning, or store credential"
+severity = "critical"
+regex = '''(?i)(android|ios|keystore|provisioning|appstore|googleplay|fastlane).{0,50}(password|private[_-]?key|api[_-]?key|issuer[_-]?id|key[_-]?id|secret)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{16,}['"]'''
+keywords = [
+  "keystore",
+  "fastlane",
+  "appstore",
+  "googleplay"
+]
+
+[[rules]]
+id = "tn-generic-sensitive-assignment"
+description = "Generic sensitive variable assignment with high-entropy value"
+severity = "medium"
+regex = '''(?i)(secret|token|api[_-]?key|private[_-]?key|password|passwd|pwd|credential|auth[_-]?key)\s*[:=]\s*['"][A-Za-z0-9._~+/=-]{32,}['"]'''
+entropy = 3.7
+keywords = [
+  "secret",
+  "token",
+  "api_key",
+  "password",
+  "credential"
+]


### PR DESCRIPTION
## Summary
- Add TN-wide secret taxonomy, severity model, and remediation rules.
- Add shared Gitleaks config covering blockchain, cloud, CI/CD, SaaS, database, auth, crypto, mobile, AI/provider, and generic sensitive assignments.
- Add fake-only negative fixture and a runtime positive fixture generator so test secrets are not stored as committed literals.

## Validation
- Parsed `security/gitleaks/tn-gitleaks.toml` with Python `tomllib`.
- Compiled 36 custom regex rules with Python `re` as a lightweight local check.
- Generated temporary positive fixture: 21 high/critical rule hits.
- Checked committed negative fixture: 0 high/critical hits.
- Checked newly added source files after path allowlist: 0 high/critical hits.
- `gitleaks` is not installed on this host, so full gitleaks execution was not run locally.

## Notes
- Repo has no `develop` branch, so this PR targets `main`.
- Real secrets committed to GitHub history must be treated as compromised; deletion or history rewrite alone is not sufficient remediation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared secret-scanning baseline with broader coverage for common credential and token patterns.
  * Introduced guidance for secret detection, severity levels, allowlists, and triage handling.

* **Documentation**
  * Added security baseline documentation to the README.
  * Added a guide for validating the secret-scanning setup locally.

* **Chores**
  * Updated ignore rules so generated planning files are not tracked by Git.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->